### PR TITLE
User folder selection + lots of other stuff

### DIFF
--- a/init.js
+++ b/init.js
@@ -9,6 +9,7 @@
 
     const node_child_process = require('node:child_process');
     const node_path = require('node:path');
+    const node_fs = require('node:fs/promises');
 
     const load = (async () => {
 
@@ -17,7 +18,7 @@
         }
 
         const { GMConstructor } = await import('./js/GMConstructor.js');
-        const res = await GMConstructor.create(plugin_name, plugin_version, node_path, node_child_process);
+        const res = await GMConstructor.create(plugin_name, plugin_version, node_path, node_child_process, node_fs);
 
         if (!res.ok) {
             

--- a/js/GMConstructor.js
+++ b/js/GMConstructor.js
@@ -56,6 +56,7 @@ export class GMConstructor {
 
         const runtime_type = projectProperties.runtime_channel_type_get();
         const runtime_res = projectProperties.runtime_get();
+        const user_res = projectProperties.user_get();
 
         if (!runtime_res.ok) {
 
@@ -105,7 +106,7 @@ export class GMConstructor {
             open_files_save();
         }
 
-        const res = await compileController.job_run(project, runtime_res.data, settings);
+        const res = await compileController.job_run(project, runtime_res.data, user_res.ok ? user_res.data : null, settings);
 
         if (!res.ok) {
 
@@ -131,7 +132,7 @@ export class GMConstructor {
         this.#runTask({
             platform: igorPaths.igor_user_platform,
             verb: 'Package',
-            runtime: 'VM',
+            runner: projectProperties.runner_get(),
             threads: 8,
             configName: projectProperties.config_name_get()
         });
@@ -141,7 +142,7 @@ export class GMConstructor {
         this.#runTask({
             platform: igorPaths.igor_user_platform,
             verb: 'Clean',
-            runtime: 'VM',
+            runner: projectProperties.runner_get(),
             threads: 8,
             configName: projectProperties.config_name_get()
         });
@@ -151,7 +152,7 @@ export class GMConstructor {
         this.#runTask({
             platform: igorPaths.igor_user_platform,
             verb: 'Run',
-            runtime: 'VM',
+            runner: projectProperties.runner_get(),
             threads: 8,
             configName: projectProperties.config_name_get()
         });

--- a/js/GMConstructor.js
+++ b/js/GMConstructor.js
@@ -164,10 +164,11 @@ export class GMConstructor {
      * @param {string} _plugin_version Current version of the plugin
      * @param {import('node:path')} node_path 
      * @param {import('node:child_process')} node_child_process
+     * @param {import('node:fs/promises')} node_fs
      * 
      * @returns {Promise<Result<GMConstructor>>}
      */
-    static async create(_plugin_name, _plugin_version, node_path, node_child_process) {
+    static async create(_plugin_name, _plugin_version, node_path, node_child_process, node_fs) {
 
         // Prevent Constructor loading when running on Rosetta, since it has a bunch of issues there.
         if (rosetta_check(node_child_process.execSync)) {
@@ -191,6 +192,7 @@ export class GMConstructor {
 
         join_path = node_path.join;
         spawn = node_child_process.spawn;
+        rm = node_fs.rm;
 
         plugin_name = _plugin_name;
         plugin_version = _plugin_version;
@@ -241,6 +243,12 @@ export let join_path;
  * @type {import('node:child_process').spawn} 
  */
 export let spawn;
+
+/** 
+ * Reference to NodeJS rm.
+ * @type {import('node:fs/promises').rm} 
+ */
+export let rm;
 
 /**
  * Make sure we aren't running on rosetta, since GMEdit has

--- a/js/compiler/RuntimeVersion.js
+++ b/js/compiler/RuntimeVersion.js
@@ -76,19 +76,10 @@ export class RuntimeVersion {
 
     /**
      * Returns whether this runtime version is supported by Constructor.
-     * At the moment, as LTS is broken, this means LTS runtimes
-     * are excluded.
      * 
      * @returns {Result<void>}
      */
     supported() {
-
-        if (this.type === 'LTS' || this.year <= 2022) {
-            return {
-                ok: false,
-                err: new Err(`LTS or <=2022 builds are currently non-functional (see https://github.com/thennothinghappened/GMEdit-Constructor/issues/5)`)
-            }
-        }
 
         return {
             ok: true,

--- a/js/compiler/igor-controller.js
+++ b/js/compiler/igor-controller.js
@@ -24,8 +24,8 @@ const jobs = [];
 export async function job_run(project, runtime, user, settings) {
 
     // for some reason if we don't clear the cache directory, changes won't apply in yyc
-    if (settings.runner === "YYC") {
-        await rm(project.dir + "/cache/", {recursive: true, force: true});
+    if (settings.runner === 'YYC') {
+        await rm(project.dir + '/cache/', {recursive: true, force: true});
     }
 
     const flags_res = job_flags_get(project, runtime.path, user?.path ?? null, settings);
@@ -93,7 +93,7 @@ function job_flags_get(project, runtime_path, user_path, settings) {
         `/rp=${runtime_path}`,
         `/runtime=${settings.runner}`,
         `/v`,
-        `/tf=${project.dir}/output/${projectName}${output_exts[igor_platform_cmd_name] ?? ""}`
+        `/tf=${project.dir}/output/${projectName}${output_exts[igor_platform_cmd_name] ?? ''}`
     ];
     if (user_path) {
         flags.push(`/uf=${user_path}`);

--- a/js/compiler/igor-controller.js
+++ b/js/compiler/igor-controller.js
@@ -3,7 +3,6 @@
  * and starting new ones on projects.
  */
 
-import { project_current_get } from '../utils/project.js';
 import { CompileLogViewer } from '../ui/editors/CompileLogViewer.js';
 import { Job } from './job/Job.js';
 import { igor_platform_cmd_name } from './igor-paths.js';
@@ -13,16 +12,24 @@ import { spawn } from '../GMConstructor.js';
 /** @type {Job[]} */
 const jobs = [];
 
+const fs = require("node:fs/promises");
+
 /**
  * Run a new job on a given project.
  * @param {GMLProject} project
  * @param {RuntimeInfo} runtime
+ * @param {UserInfo?} user
  * @param {IgorSettings} settings
  * @returns {Promise<Result<Job>>}
  */
-export async function job_run(project, runtime, settings) {
+export async function job_run(project, runtime, user, settings) {
 
-    const flags_res = job_flags_get(project, runtime.path, settings);
+    // for some reason if we don't clear the cache directory, changes won't apply in yyc
+    if (settings.runner === "YYC") {
+        await fs.rm(project.dir + "/cache/", {recursive: true, force: true});
+    }
+
+    const flags_res = job_flags_get(project, runtime.path, user?.path ?? null, settings);
 
     if (!flags_res.ok) {
         return {
@@ -72,20 +79,43 @@ function job_remove(job) {
  * Select the flags for Igor to run the job.
  * @param {GMLProject} project
  * @param {string} runtime_path
+ * @param {string?} user_path
  * @param {IgorSettings} settings
  * @returns {Result<string[]>}
  */
-function job_flags_get(project, runtime_path, settings) {
+function job_flags_get(project, runtime_path, user_path, settings) {
+
+    /**
+     * @type {{[K in IgorPlatform]?: string}}
+    */
+    const exts = {
+        Windows: ".zip",
+        Mac: ".zip",
+        Linux: ".appimage",
+    };
+
+    let projectName = $gmedit['gml.Project'].current.name;
+    // Remove .yyp file extension
+    projectName = projectName.substring(0, projectName.length - 4);
+
     const flags = [
         `/project=${project.path}`,
         `/config=${settings.configName}`,
         `/rp=${runtime_path}`,
-        `/runtime=${settings.runtime}`
+        `/runtime=${settings.runner}`,
+        `/v`,
+        `/tf=${project.dir}/output/${projectName}${exts[igor_platform_cmd_name] ?? ""}`
     ];
+    if (user_path)
+        flags.push(`/uf=${user_path}`);
 
     switch (settings.verb) {
-        case 'Run':
         case 'Package':
+            if (['Windows', 'Mac'].includes(igor_platform_cmd_name))
+                settings.verb = 'PackageZip';
+            break;
+
+        case 'Run':
         case 'Clean':
             break;
 

--- a/js/compiler/igor-paths.js
+++ b/js/compiler/igor-paths.js
@@ -2,6 +2,9 @@
 import { join_path } from '../GMConstructor.js';
 import { Err } from '../utils/Err.js';
 
+const process = require('node:process');
+const appdata = process.env?.AppData ?? '';
+
 /**
  * Mappings of NodeJS platforms to various Igor information.
  * @type {{[key in NodeJS.Platform]: IgorPlatformInfo}}
@@ -15,7 +18,12 @@ const igor_platform_map = {
             Stable: 'C:\\ProgramData\\GameMakerStudio2\\Cache\\runtimes',
             Beta:   'C:\\ProgramData\\GameMakerStudio2-Beta\\Cache\\runtimes',
             LTS:    'C:\\ProgramData\\GameMakerStudio2-LTS\\Cache\\runtimes'
-        }
+        },
+        default_user_paths: {
+            Stable: appdata + '\\GameMakerStudio2',
+            Beta:   appdata + '\\GameMakerStudio2-Beta',
+            LTS:    appdata + '\\GameMakerStudio2-LTS'
+        },
     },
     'darwin': {
         platform_executable_extension: '',
@@ -25,16 +33,27 @@ const igor_platform_map = {
             Stable: '/Users/Shared/GameMakerStudio2/Cache/runtimes',
             Beta:   '/Users/Shared/GameMakerStudio2-Beta/Cache/runtimes',
             LTS:    '/Users/Shared/GameMakerStudio2-LTS/Cache/runtimes'
+        },
+        default_user_paths: {
+            Stable: '~/.config/GameMakerStudio2',
+            Beta:   '~/.config/GameMakerStudio2-Beta',
+            LTS:    '~/.config/GameMakerStudio2-LTS'
         }
     },
     'linux': {
         platform_executable_extension: '',
         platform_path_name: 'ubuntu', // TODO: can't check this right now
         user_platform: 'Linux',
+        users_path: '/please/specify/your/userdata/paths',
         default_runtime_paths: {
             Stable: '/please/specify/your/runtime/paths',
             Beta:   '/please/specify/your/runtime/paths',
             LTS:    '/please/specify/your/runtime/paths'
+        },
+        default_user_paths: {
+            Stable: '/please/specify/your/userdata/paths',
+            Beta:   '/please/specify/your/userdata/paths',
+            LTS:    '/please/specify/your/userdata/paths'
         }
     }
 };
@@ -43,6 +62,11 @@ const igor_platform_map = {
  * Default paths to the runtimes for the host OS.
  */
 export const def_runtime_paths = igor_platform_map[process.platform].default_runtime_paths;
+
+/**
+ * Default paths to the userdata folders for the host OS.
+ */
+export const def_user_paths = igor_platform_map[process.platform].default_user_paths;
 
 /**
  * {@link IgorPlatform} to native build for the host OS. 

--- a/js/compiler/igor-paths.js
+++ b/js/compiler/igor-paths.js
@@ -1,9 +1,7 @@
 
 import { join_path } from '../GMConstructor.js';
-import { Err } from '../utils/Err.js';
 
-const process = require('node:process');
-const appdata = process.env?.AppData ?? 'C:\\Users\\PLEASE_SPECIFY_USERNAME\\AppData\\Roaming';
+const windowsAppdata = process.env?.AppData ?? 'C:\\Users\\PLEASE_SPECIFY_USERNAME\\AppData\\Roaming';
 
 /**
  * Mappings of NodeJS platforms to various Igor information.
@@ -20,9 +18,9 @@ const igor_platform_map = {
             LTS:    'C:\\ProgramData\\GameMakerStudio2-LTS\\Cache\\runtimes'
         },
         default_user_paths: {
-            Stable: appdata + '\\GameMakerStudio2',
-            Beta:   appdata + '\\GameMakerStudio2-Beta',
-            LTS:    appdata + '\\GameMakerStudio2-LTS'
+            Stable: windowsAppdata + '\\GameMakerStudio2',
+            Beta:   windowsAppdata + '\\GameMakerStudio2-Beta',
+            LTS:    windowsAppdata + '\\GameMakerStudio2-LTS'
         },
     },
     'darwin': {
@@ -55,6 +53,16 @@ const igor_platform_map = {
             LTS:    '/please/specify/your/user/paths'
         }
     }
+};
+
+/**
+ * Mappings of Igor targets to output file extensions. TODO: other targets
+ * @type {{[K in IgorPlatform]?: string}}
+*/
+export const output_exts = {
+    Windows: ".zip",
+    Mac: ".zip",
+    Linux: ".appimage",
 };
 
 /**

--- a/js/compiler/igor-paths.js
+++ b/js/compiler/igor-paths.js
@@ -60,9 +60,9 @@ const igor_platform_map = {
  * @type {{[K in IgorPlatform]?: string}}
 */
 export const output_exts = {
-    Windows: ".zip",
-    Mac: ".zip",
-    Linux: ".appimage",
+    Windows: '.zip',
+    Mac: '.zip',
+    Linux: '.appimage',
 };
 
 /**

--- a/js/compiler/igor-paths.js
+++ b/js/compiler/igor-paths.js
@@ -3,7 +3,7 @@ import { join_path } from '../GMConstructor.js';
 import { Err } from '../utils/Err.js';
 
 const process = require('node:process');
-const appdata = process.env?.AppData ?? '';
+const appdata = process.env?.AppData ?? 'C:\\Users\\PLEASE_SPECIFY_USERNAME\\AppData\\Roaming';
 
 /**
  * Mappings of NodeJS platforms to various Igor information.
@@ -44,16 +44,15 @@ const igor_platform_map = {
         platform_executable_extension: '',
         platform_path_name: 'ubuntu', // TODO: can't check this right now
         user_platform: 'Linux',
-        users_path: '/please/specify/your/userdata/paths',
         default_runtime_paths: {
             Stable: '/please/specify/your/runtime/paths',
             Beta:   '/please/specify/your/runtime/paths',
             LTS:    '/please/specify/your/runtime/paths'
         },
         default_user_paths: {
-            Stable: '/please/specify/your/userdata/paths',
-            Beta:   '/please/specify/your/userdata/paths',
-            LTS:    '/please/specify/your/userdata/paths'
+            Stable: '/please/specify/your/user/paths',
+            Beta:   '/please/specify/your/user/paths',
+            LTS:    '/please/specify/your/user/paths'
         }
     }
 };

--- a/js/compiler/job/Job.js
+++ b/js/compiler/job/Job.js
@@ -18,6 +18,9 @@ export class Job {
     #stdout = '';
 
     #stopped = false;
+    
+    /** @type {number|null} */
+    #exitCode = null;
 
     /** @type {{[key in JobEvent]: Set<(data: any?) => void>}} */
     #listeners = {
@@ -59,6 +62,8 @@ export class Job {
     #onExit = () => {
 
         this.#stopped = true;
+        if (this.#exitCode != -1)
+            this.#exitCode = this.#process.exitCode;
         
         Job.#notify(this.#listeners.stop, job_parse_stdout(this.stdout));
         this.#process.removeAllListeners();
@@ -88,6 +93,7 @@ export class Job {
      * Stop the job.
      */
     stop = () => {
+        this.#exitCode = -1;
         this.#process.kill();
     }
 
@@ -114,6 +120,9 @@ export class Job {
 
     /** Whether this job has stopped yet. */
 	get stopped() { return this.#stopped; }
+
+    /** The exit code of this process (or -1 for cancelled). */
+	get exitCode() { return this.#exitCode; }
 
     /** The command this job is running. */
 	get command() { return this.#settings.verb; }

--- a/js/compiler/job/Job.js
+++ b/js/compiler/job/Job.js
@@ -62,7 +62,7 @@ export class Job {
     #onExit = () => {
 
         this.#stopped = true;
-        if (this.#exitCode != -1)
+        if (this.#exitCode !== -1)
             this.#exitCode = this.#process.exitCode;
         
         Job.#notify(this.#listeners.stop, job_parse_stdout(this.stdout));

--- a/js/global.d.ts
+++ b/js/global.d.ts
@@ -252,6 +252,10 @@ declare type JobEvent =
     'output'    |
     'stop'      ;
 
+declare type JobStatus = 
+    { status: 'running' } |
+    { status: 'stopped', stoppedByUser: boolean, exitCode: number };
+
 declare type GMPlugin = {
     init: () => void,
     cleanup: () => void

--- a/js/global.d.ts
+++ b/js/global.d.ts
@@ -3,6 +3,7 @@ declare type PreferencesData = {
     /** Globally selected runtime options that may be overriden by projects. */
     runtime_opts: {
         type: RuntimeChannelType;
+        runner: RunnerType;
 
         type_opts: {
             [key in RuntimeChannelType]: RuntimePreference;
@@ -34,7 +35,12 @@ declare type ProjectPreferencesData = {
     /**
      * Chosen runtime version to use.
      */
-    runtime_version: string?;
+    runtime_version: string;
+
+    /**
+     * Chosen runner type to use.
+     */
+    runner: RunnerType;
 
 };
 
@@ -43,12 +49,22 @@ declare type RuntimeChannelType =
     'Beta'      |
     'LTS'       ;
 
+declare type RunnerType =
+    'VM'  |
+    'YYC' ;
+
 declare type RuntimePreference = {
     /** Where we should search for the list of runtimes. */
     search_path: string;
-    
+
+    /** Where we should search for the list of users. */
+    users_path: string;
+
     /** Chosen runtime to use. */
     choice: string?;
+
+    /** Chosen user to use. */
+    user: string?;
 };
 
 /**
@@ -74,8 +90,6 @@ declare interface IRuntimeVersion {
 
     /**
      * Returns whether this runtime version is supported by Constructor.
-     * At the moment, as LTS is broken, this means LTS runtimes
-     * are excluded.
      */
     supported(): Result<void>;
 
@@ -96,6 +110,14 @@ declare type RuntimeInfo = {
     version: IRuntimeVersion;
     path: string;
     igor_path: string;
+};
+
+/**
+ * Information for a specific found user.
+ */
+declare type UserInfo = {
+    path: string;
+    name: string;
 };
 
 /**
@@ -137,9 +159,9 @@ declare type IgorSettings = {
     verb: IgorVerb;
 
     /**
-     * Which runtime to use - default is VM.
+     * Which runner to use - default is VM.
      */
-    runtime: 'VM'|'YYC';
+    runner: RunnerType;
 
     /**
      * How many threads to use for this compilation.
@@ -150,6 +172,11 @@ declare type IgorSettings = {
      * Name of the Build Config to use for this compilation.
      */
     configName: string;
+
+    /**
+     * Path to the user folder. Required for packaging.
+     */
+    userFolder?: string;
 
     /**
      * Launch the executable on the target device after building;
@@ -201,12 +228,24 @@ declare type IgorPlatformInfo = {
     default_runtime_paths: {
         [key in RuntimeChannelType]: string
     };
+
+    /**
+     * Default directories as per https://manual-en.yoyogames.com/Settings/Building_via_Command_Line.htm
+     * to find user folders.
+     * 
+     * Note that this only covers Windows and MacOS, elsewhere will crash trying to index these
+     * as I don't know where the location is for Linux.
+     */
+    default_user_paths: {
+        [key in RuntimeChannelType]: string
+    };
 }
 
 declare type IgorVerb = 
-    'Run'       |
-    'Package'   |
-    'Clean'     ;
+    'Run'        |
+    'Package'    |
+    'PackageZip' |
+    'Clean'      ;
 
 declare type JobEvent =
     'stdout'    |

--- a/js/preferences/Preferences.js
+++ b/js/preferences/Preferences.js
@@ -467,9 +467,10 @@ async function user_list_load_path(type, users_path) {
         })
         .sort((a, b) => +(a.name > b.name));
 
-    // Search each result to check if its a valid user or just a folder in the users folder.
+    // Search each result to check if it's actually a valid user, or just a folder in the users folder
+    // (e.g Cache).
     const valid = await Promise.all(
-        users.map(user => fileExists(join_path(user.path, "local_settings.json")))
+        users.map(user => fileExists(join_path(user.path, 'local_settings.json')))
     );
 
     return {

--- a/js/preferences/Preferences.js
+++ b/js/preferences/Preferences.js
@@ -572,7 +572,7 @@ export async function __setup__() {
                 } else {
                     ConstructorControlPanel.showDebug(`Failed to load ${runtime_type} runtimes list`, result.err);
                 }
-                if (!options.choice && runtimes[runtime_type] && (runtimes[runtime_type]?.length ?? 0) > 0) {
+                if ((options.choice === undefined || options.choice === null) && runtimes[runtime_type] && (runtimes[runtime_type]?.length ?? 0) > 0) {
                     // @ts-ignore
                     options.choice = runtimes[runtime_type][0].version.toString();
                 }
@@ -585,7 +585,7 @@ export async function __setup__() {
                 } else {
                     ConstructorControlPanel.showDebug(`Failed to load ${runtime_type} users list`, result.err);
                 }
-                if (!options.user && users[runtime_type] && (users[runtime_type]?.length ?? 0) > 0) {
+                if ((options.user === undefined || options.user === null) && users[runtime_type] && (users[runtime_type]?.length ?? 0) > 0) {
                     // @ts-ignore
                     options.user = users[runtime_type][0].name.toString();
                 }

--- a/js/preferences/Preferences.js
+++ b/js/preferences/Preferences.js
@@ -613,6 +613,20 @@ export async function __setup__() {
         ConstructorControlPanel.showDebug('Failed to load LTS users list', user_lts_res.err);
     }
 
+    // If some runtimes/users aren't filled in but there is an available runtime version/user,
+    // fill them in automatically
+    for (const runtime_type of valid_runtime_types) {
+        const options = prefs.runtime_opts.type_opts[runtime_type];
+        if (!options.choice && runtimes[runtime_type] && (runtimes[runtime_type]?.length ?? 0) > 0) {
+            // @ts-ignore
+            options.choice = runtimes[runtime_type][0].version.toString();
+        }
+        if (!options.user && users[runtime_type] && (users[runtime_type]?.length ?? 0) > 0) {
+            // @ts-ignore
+            options.user = users[runtime_type][0].name.toString();
+        }
+    }
+
     __ready__ = true;
 
     return {

--- a/js/preferences/Preferences.js
+++ b/js/preferences/Preferences.js
@@ -3,9 +3,10 @@
  * and runtime list.
  */
 
-import { def_runtime_paths, igor_path_segment } from '../compiler/igor-paths.js';
+import { def_runtime_paths, def_user_paths, igor_path_segment } from '../compiler/igor-paths.js';
 import { fileExists, readFile, readdir, writeFile } from '../utils/file.js';
 import { Err } from '../utils/Err.js';
+import { deep_assign } from '../utils/object.js';
 import { join_path, plugin_name } from '../GMConstructor.js';
 import { runtime_version_parse } from '../compiler/RuntimeVersion.js';
 import { ConstructorControlPanel } from '../ui/editors/ConstructorControlPanel.js';
@@ -13,24 +14,34 @@ import { ConstructorControlPanel } from '../ui/editors/ConstructorControlPanel.j
 /** @type {RuntimeChannelType[]} */
 export const valid_runtime_types = ['Stable', 'Beta', 'LTS'];
 
+/** @type {RunnerType[]} */
+export const valid_runner_types = ['VM', 'YYC'];
+
 /** @type {Readonly<PreferencesData>} */
 const prefs_default = {
     runtime_opts: {
         // Default runtime to use is probably going to be stable.
         type: 'Stable',
+        runner: 'VM',
 
         type_opts: {
             Stable: {
                 search_path: def_runtime_paths.Stable,
-                choice: null
+                users_path: def_user_paths.Stable,
+                choice: null,
+                user: null
             },
             Beta: {
                 search_path: def_runtime_paths.Beta,
-                choice: null
+                users_path: def_user_paths.Beta,
+                choice: null,
+                user: null
             },
             LTS: {
                 search_path: def_runtime_paths.LTS,
-                choice: null
+                users_path: def_user_paths.LTS,
+                choice: null,
+                user: null
             }
         }
     },
@@ -49,6 +60,18 @@ let prefs = Object.create(prefs_default);
  * @type { { [key in RuntimeChannelType]: RuntimeInfo[]? } }
  */
 const runtimes = {
+    Stable: null,
+    Beta: null,
+    LTS: null
+};
+
+/**
+ * List of users for each type.
+ * Populated after loading the list.
+ * 
+ * @type { { [key in RuntimeChannelType]: UserInfo[]? } }
+ */
+const users = {
     Stable: null,
     Beta: null,
     LTS: null
@@ -104,6 +127,33 @@ export function save_on_run_task_set(save_on_run_task) {
 }
 
 /**
+ * Get the desired runner type.
+ * @returns {RunnerType}
+ */
+export function runner_get() {
+    return prefs.runtime_opts.runner;
+}
+
+/**
+ * The default runner type used globally.
+ * @returns {RunnerType}
+ */
+export function runner_project_get() {
+    return prefs.runtime_opts.runner;
+}
+
+/**
+ * The default runner type used globally.
+ * @param {RunnerType} runner 
+ */
+export function runner_set(runner) {
+
+    prefs.runtime_opts.runner = runner;
+    return save();
+
+}
+
+/**
  * The default runtime type used globally.
  */
 export function runtime_channel_type_get() {
@@ -138,11 +188,37 @@ export function runtime_version_set(type, choice) {
 }
 
 /**
+ * Get the global choice for default user for a given type.
+ * @param {RuntimeChannelType} [type] 
+ */
+export function user_get(type = runtime_channel_type_get()) {
+    return prefs.runtime_opts.type_opts[type].user;
+}
+
+/**
+ * Set the global choice for default runtime for a given type.
+ * @param {RuntimeChannelType} type 
+ * @param {string?} user 
+ */
+export function user_set(type, user) {
+    prefs.runtime_opts.type_opts[type].user = user;
+    return save();
+}
+
+/**
  * Get the search path for runtime of a given type.
  *  @param {RuntimeChannelType} type 
  */
 export function runtime_search_path_get(type) {
     return prefs.runtime_opts.type_opts[type].search_path;
+}
+
+/**
+ * Get the users path for runtime of a given type.
+ *  @param {RuntimeChannelType} type 
+ */
+export function users_search_path_get(type) {
+    return prefs.runtime_opts.type_opts[type].users_path;
 }
 
 /**
@@ -152,6 +228,15 @@ export function runtime_search_path_get(type) {
  */
 export function runtime_versions_get_for_type(type) {
    return runtimes[type];
+};
+
+/**
+ * Function to get a list of user names for a given runtime type.
+ * @param {RuntimeChannelType} type
+ * @returns {UserInfo[]?}
+ */
+export function users_get_for_type(type) {
+   return users[type];
 };
 
 /**
@@ -202,6 +287,53 @@ export async function runtime_search_path_set(type, search_path) {
 }
 
 /**
+ * Set the users path for runtime of a given type.
+ * @param {RuntimeChannelType} type 
+ * @param {string} users_path 
+ */
+export async function users_search_path_set(type, users_path) {
+
+    prefs.runtime_opts.type_opts[type].users_path = users_path;
+    await save();
+
+    users[type] = null;
+
+    const res = await user_list_load_type(type);
+
+    if (!res.ok) {
+
+        const err = new Err(
+            `Failed to load ${type} user list`,
+            res.err,
+            'Make sure the users path is valid!'
+        );
+
+        return ConstructorControlPanel
+            .view(true)
+            .showError(err.message, err);
+    }
+
+    users[type] = res.data;
+
+    const choice = user_get(type);
+
+    if (
+        choice !== undefined && 
+        users[type]?.find(user => user.name === choice) === undefined
+    ) {
+
+        const err = new Err(`User "${choice}" not available in new users path "${users_path}".`);
+
+        ConstructorControlPanel
+            .view(false)
+            .showWarning(err.message, err);
+        
+        user_set(type, users[type]?.at(0)?.name?.toString() ?? null);
+    }
+
+}
+
+/**
  * Save preferences back to the file.
  */
 export function save() {
@@ -225,6 +357,17 @@ async function runtime_list_load_type(type = runtime_channel_type_get()) {
 
     const { search_path } = global_runtime_opts_get(type);
     return runtime_list_load_path(type, search_path);
+}
+
+/**
+ * Load the list of users for the provided users path for a type.
+ * @param {RuntimeChannelType} [type] 
+ * @returns {Promise<Result<UserInfo[]>>}
+ */
+async function user_list_load_type(type = runtime_channel_type_get()) {
+
+    const { users_path } = global_runtime_opts_get(type);
+    return user_list_load_path(type, users_path);
 }
 
 /**
@@ -304,6 +447,46 @@ async function runtime_list_load_path(type, search_path) {
 }
 
 /**
+ * Load the list of users for the provided search path.
+ * @param {RuntimeChannelType} type 
+ * @param {String} users_path 
+ * @returns {Promise<Result<UserInfo[]>>}
+ */
+async function user_list_load_path(type, users_path) {
+
+    const dir_res = await readdir(users_path);
+    
+    if (!dir_res.ok) {
+        return {
+            ok: false,
+            err: new Err(`Failed to read users path '${users_path}': ${dir_res.err}`),
+        };
+    }
+
+    /** @type {UserInfo[]} */
+    // @ts-thanks-for-epic-type-inference-it-really-works-here
+    // @ts-ignore
+    const users = dir_res.data
+        .map(dirname => {
+            return {
+                path: join_path(users_path, dirname),
+                name: dirname
+            };
+        })
+        .sort((a, b) => +(a.name > b.name));
+
+    // Search each result to check if its a valid user or just a folder in the users folder.
+    const valid = await Promise.all(
+        users.map(user => fileExists(join_path(user.path, "local_settings.json")))
+    );
+
+    return {
+        ok: true,
+        data: users.filter((_, i) => valid[i])
+    };
+}
+
+/**
  * Init a new instance of Preferences asynchronously (requires loading file.)
  * @returns {Promise<Result<void>>}
  */
@@ -379,14 +562,20 @@ export async function __setup__() {
 
     }
     
-    prefs = Object.create(prefs_default);
-    Object.assign(prefs, loaded_prefs);
+    prefs = structuredClone(prefs_default);
+    deep_assign(prefs, loaded_prefs);
 
     const stable_req = runtime_list_load_type('Stable');
     const beta_req = runtime_list_load_type('Beta');
     const lts_req = runtime_list_load_type('LTS');
+    const user_stable_req = user_list_load_type('Stable');
+    const user_beta_req = user_list_load_type('Beta');
+    const user_lts_req = user_list_load_type('LTS');
 
-    const [stable_res, beta_res, lts_res] = await Promise.all([stable_req, beta_req, lts_req]);
+    const [
+        stable_res, beta_res, lts_res,
+        user_stable_res, user_beta_res, user_lts_res,
+    ] = await Promise.all([stable_req, beta_req, lts_req, user_stable_req, user_beta_req, user_lts_req]);
 
     if (stable_res.ok) {
         runtimes.Stable = stable_res.data;
@@ -404,6 +593,24 @@ export async function __setup__() {
         runtimes.LTS = lts_res.data;
     } else {
         ConstructorControlPanel.showDebug('Failed to load LTS runtimes list', lts_res.err);
+    }
+
+    if (user_stable_res.ok) {
+        users.Stable = user_stable_res.data;
+    } else {
+        ConstructorControlPanel.showDebug('Failed to load Stable users list', user_stable_res.err);
+    }
+
+    if (user_beta_res.ok) {
+        users.Beta = user_beta_res.data;
+    } else {
+        ConstructorControlPanel.showDebug('Failed to load Beta users list', user_beta_res.err);
+    }
+
+    if (user_lts_res.ok) {
+        users.LTS = user_lts_res.data;
+    } else {
+        ConstructorControlPanel.showDebug('Failed to load LTS users list', user_lts_res.err);
     }
 
     __ready__ = true;

--- a/js/preferences/Preferences.js
+++ b/js/preferences/Preferences.js
@@ -572,10 +572,15 @@ export async function __setup__() {
                 } else {
                     ConstructorControlPanel.showDebug(`Failed to load ${runtime_type} runtimes list`, result.err);
                 }
-                if ((options.choice === undefined || options.choice === null) && runtimes[runtime_type] && (runtimes[runtime_type]?.length ?? 0) > 0) {
-                    // @ts-ignore
-                    options.choice = runtimes[runtime_type][0].version.toString();
+
+                if (options.choice !== undefined && options.choice !== null) {
+                    return result;
                 }
+                if (!runtimes[runtime_type] || (runtimes[runtime_type]?.length ?? 0) == 0) {
+                    return result;
+                }
+                // @ts-ignore
+                options.choice = runtimes[runtime_type][0].version.toString();
                 return result;
             }));
         reqs.push(user_list_load_type(runtime_type)
@@ -585,10 +590,15 @@ export async function __setup__() {
                 } else {
                     ConstructorControlPanel.showDebug(`Failed to load ${runtime_type} users list`, result.err);
                 }
-                if ((options.user === undefined || options.user === null) && users[runtime_type] && (users[runtime_type]?.length ?? 0) > 0) {
-                    // @ts-ignore
-                    options.user = users[runtime_type][0].name.toString();
+                
+                if (options.user !== undefined && options.user !== null) {
+                    return result;
                 }
+                if (!users[runtime_type] || (users[runtime_type]?.length ?? 0) == 0) {
+                    return result;
+                }
+                // @ts-ignore
+                options.user = users[runtime_type][0].name.toString();
                 return result;
             }));
     }

--- a/js/preferences/ProjectProperties.js
+++ b/js/preferences/ProjectProperties.js
@@ -101,7 +101,7 @@ export function runtime_channel_type_set(runtime_type) {
  * @returns {string|null}
  */
 export function runtime_version_get() {
-    return properties.runtime_version ?? preferences.runtime_version_get(runtime_project_channel_type_get());
+    return properties.runtime_version ?? preferences.runtime_version_get(runtime_channel_type_get());
 }
 
 /**

--- a/js/preferences/ProjectProperties.js
+++ b/js/preferences/ProjectProperties.js
@@ -43,6 +43,33 @@ export function config_name_set(config_name) {
 }
 
 /**
+ * Get the desired runner type.
+ * @returns {RunnerType}
+ */
+export function runner_get() {
+    return properties.runner ?? preferences.runner_get();
+}
+
+/**
+ * Get the desired runner type for this project (without falling back to the global option).
+ * @returns {RunnerType|undefined}
+ */
+export function runner_project_get() {
+    return properties.runner;
+}
+
+/**
+ * Set the desired runtime channel type.
+ * @param {RunnerType|undefined} runner 
+ */
+export function runner_set(runner) {
+
+    properties.runner = runner;
+    return save();
+
+}
+
+/**
  * Get the desired runtime channel type.
  * @returns {RuntimeChannelType}
  */
@@ -51,19 +78,53 @@ export function runtime_channel_type_get() {
 }
 
 /**
+ * Get the desired runtime channel type for this project (without falling back to the global option).
+ * @returns {RuntimeChannelType|undefined}
+ */
+export function runtime_project_channel_type_get() {
+    return properties.runtime_type;
+}
+
+/**
  * Set the desired runtime channel type.
  * @param {RuntimeChannelType|undefined} runtime_type 
  */
 export function runtime_channel_type_set(runtime_type) {
 
-    console.log(runtime_type);
     properties.runtime_type = runtime_type;
     return save();
 
 }
 
 /**
- * Get the runtime to use for the current project.
+ * Get the desired runtime version for this project.
+ * @returns {string|null}
+ */
+export function runtime_version_get() {
+    return properties.runtime_version ?? preferences.runtime_version_get(runtime_project_channel_type_get());
+}
+
+/**
+ * Get the desired runtime channel type for this project (without falling back to the global option).
+ * @returns {string|undefined}
+ */
+export function runtime_project_version_get() {
+    return properties.runtime_version;
+}
+
+/**
+ * Set the desired runtime channel type.
+ * @param {string|undefined} runtime_type 
+ */
+export function runtime_version_set(runtime_type) {
+
+    properties.runtime_version = runtime_type;
+    return save();
+
+}
+
+/**
+ * Get the runtime version to use for the current project.
  * @returns {Result<RuntimeInfo>}
  */
 export function runtime_get() {
@@ -78,7 +139,7 @@ export function runtime_get() {
         };
     }
 
-    const version = preferences.runtime_version_get(type) ?? desired_runtime_list[0]?.version?.toString();
+    const version = runtime_version_get() ?? desired_runtime_list[0]?.version?.toString();
     const runtime = desired_runtime_list.find(runtime => runtime.version.toString() === version);
 
     if (runtime === undefined) {
@@ -91,6 +152,38 @@ export function runtime_get() {
     return {
         ok: true,
         data: runtime
+    };
+}
+/**
+
+ * Get the user to use for the current project.
+ * @returns {Result<UserInfo>}
+ */
+export function user_get() {
+
+    const type = runtime_channel_type_get();
+    const desired_user_list = preferences.users_get_for_type(type);
+
+    if (desired_user_list === null) {
+        return {
+            ok: false,
+            err: new Err(`Users for runtime ${type} list not loaded!`)
+        };
+    }
+
+    const name = preferences.user_get(type) ?? desired_user_list[0]?.name?.toString();
+    const user = desired_user_list.find(user => user.name.toString() === name);
+
+    if (user === undefined) {
+        return {
+            ok: false,
+            err: new Err(`Failed to find any users for runtime ${type}`)
+        };
+    }
+
+    return {
+        ok: true,
+        data: user
     };
 }
 

--- a/js/ui/HamburgerOptions.js
+++ b/js/ui/HamburgerOptions.js
@@ -190,7 +190,7 @@ export class HamburgerOptions {
     #setEnableMenuItems = (enabled) => {
         // @ts-ignore
         for (const item of this.#menu_items_container.submenu.items) {
-            if (item.id != 'constructor-control_panel')
+            if (item.id !== 'constructor-control_panel')
                 item.enabled = enabled;
         }
     }

--- a/js/ui/HamburgerOptions.js
+++ b/js/ui/HamburgerOptions.js
@@ -190,8 +190,9 @@ export class HamburgerOptions {
     #setEnableMenuItems = (enabled) => {
         // @ts-ignore
         for (const item of this.#menu_items_container.submenu.items) {
-            if (item.id !== 'constructor-control_panel')
+            if (item.id !== 'constructor-control_panel') {
                 item.enabled = enabled;
+            }
         }
     }
 

--- a/js/ui/HamburgerOptions.js
+++ b/js/ui/HamburgerOptions.js
@@ -59,7 +59,7 @@ export class HamburgerOptions {
         this.#menu_items_container = new Electron_MenuItem({
             id: 'constructor-menu',
             label: 'Constructor',
-            enabled: false,
+            enabled: true,
             submenu: [
                 this.#menu_items.control_panel,
                 this.#menu_items.compile,
@@ -188,10 +188,10 @@ export class HamburgerOptions {
      * @param {boolean} enabled
      */
     #setEnableMenuItems = (enabled) => {
-        this.#menu_items_container.enabled = enabled;
         // @ts-ignore
         for (const item of this.#menu_items_container.submenu.items) {
-            item.enabled = enabled;
+            if (item.id != 'constructor-control_panel')
+                item.enabled = enabled;
         }
     }
 

--- a/js/ui/PreferencesMenu.js
+++ b/js/ui/PreferencesMenu.js
@@ -68,8 +68,9 @@ export function menu_create(prefs_group, on_change_runtime_channel) {
         (value) => {
             // @ts-ignore
             preferences.runtime_channel_type_set(value);
-            if (on_change_runtime_channel)
+            if (on_change_runtime_channel) {
                 on_change_runtime_channel();
+            }
         }
     );
 
@@ -92,7 +93,6 @@ export function menu_create(prefs_group, on_change_runtime_channel) {
                 if (path === preferences.runtime_search_path_get(type)) {
                     return;
                 }
-
                 await preferences.runtime_search_path_set(type, path);
                 UIDropdownMutate(
                     version_dropdown,
@@ -120,7 +120,6 @@ export function menu_create(prefs_group, on_change_runtime_channel) {
                 if (path === preferences.users_search_path_get(type)) {
                     return;
                 }
-
                 await preferences.users_search_path_set(type, path);
                 UIDropdownMutate(
                     user_dropdown,

--- a/js/ui/editors/CompileLogViewer.js
+++ b/js/ui/editors/CompileLogViewer.js
@@ -28,7 +28,9 @@ class KConstructorOutput extends ConstructorViewFileKind {
      * @param {Job} job
      */
     static getJobName = (job) => {
-        return `${job.projectDisplayName} - ${job.command}${job.stopped ? ' - Finished' : ''}`;
+        return `${job.projectDisplayName} - ${job.command}${
+            job.stopped ? (' - ' + (job.exitCode == -1 ? 'Stopped' : ((job.exitCode != null && job.exitCode > 0) ? 'Failed' : 'Finished'))) : ''
+        }`;
     }
 
 }
@@ -171,7 +173,8 @@ export class CompileLogViewer extends ConstructorEditorView {
     }
 
     stopJob = () => {
-        this.job.stop();
+        if (!this.job.stopped)
+            this.job.stop();
     }
 
     /**

--- a/js/ui/editors/CompileLogViewer.js
+++ b/js/ui/editors/CompileLogViewer.js
@@ -28,9 +28,8 @@ class KConstructorOutput extends ConstructorViewFileKind {
      * @param {Job} job
      */
     static getJobName = (job) => {
-        return `${job.projectDisplayName} - ${job.command}${
-            job.stopped ? (' - ' + (job.exitCode === -1 ? 'Stopped' : ((job.exitCode !== null && job.exitCode > 0) ? 'Failed' : 'Finished'))) : ''
-        }`;
+        const statusDisplay = job.statusDisplay === '' ? '' : (' - ' + job.statusDisplay);
+        return `${job.projectDisplayName} - ${job.command}${statusDisplay}`;
     }
 
 }
@@ -173,8 +172,9 @@ export class CompileLogViewer extends ConstructorEditorView {
     }
 
     stopJob = () => {
-        if (!this.job.stopped)
+        if (this.job.status.status !== 'stopped') {
             this.job.stop();
+        }
     }
 
     /**

--- a/js/ui/editors/CompileLogViewer.js
+++ b/js/ui/editors/CompileLogViewer.js
@@ -29,7 +29,7 @@ class KConstructorOutput extends ConstructorViewFileKind {
      */
     static getJobName = (job) => {
         return `${job.projectDisplayName} - ${job.command}${
-            job.stopped ? (' - ' + (job.exitCode == -1 ? 'Stopped' : ((job.exitCode != null && job.exitCode > 0) ? 'Failed' : 'Finished'))) : ''
+            job.stopped ? (' - ' + (job.exitCode === -1 ? 'Stopped' : ((job.exitCode !== null && job.exitCode > 0) ? 'Failed' : 'Finished'))) : ''
         }`;
     }
 

--- a/js/utils/object.js
+++ b/js/utils/object.js
@@ -1,20 +1,12 @@
 /**
- * @param {any} obj
- * @returns {boolean}
- */
-export function is_object(obj) {
-    return obj && obj instanceof Object;
-}
-
-/**
  * @param {any} to
  * @param {any} obj
  * @returns {any}
  */
 export function deep_assign(to, obj) {
-	if (!is_object(obj) || !is_object(to)) return to;
+	if (!(obj instanceof Object) || !(to instanceof Object)) return to;
 	for (const key of Object.keys(obj)) {
-		if (is_object(to[key])) {
+		if (to[key] instanceof Object) {
 			deep_assign(to[key], obj[key]);
 		} else {
 			to[key] = obj[key];

--- a/js/utils/object.js
+++ b/js/utils/object.js
@@ -1,0 +1,24 @@
+/**
+ * @param {any} obj
+ * @returns {boolean}
+ */
+export function is_object(obj) {
+    return obj && obj instanceof Object;
+}
+
+/**
+ * @param {any} to
+ * @param {any} obj
+ * @returns {any}
+ */
+export function deep_assign(to, obj) {
+	if (!is_object(obj) || !is_object(to)) return to;
+	for (const key of Object.keys(obj)) {
+		if (is_object(to[key])) {
+			deep_assign(to[key], obj[key]);
+		} else {
+			to[key] = obj[key];
+		}
+	}
+	return to;
+}

--- a/js/utils/ui.js
+++ b/js/utils/ui.js
@@ -13,6 +13,8 @@ export function UIDropdownMutate(root, opts, value) {
     // @ts-ignore
     const sel = root.querySelector('select');
 
+    const oldValue = sel.value;
+
     for (const el of Array.from(sel.childNodes)) {
         sel.removeChild(el);
     }
@@ -25,7 +27,9 @@ export function UIDropdownMutate(root, opts, value) {
         sel.appendChild(el);
     }
 
-    if (value === undefined && opts.includes(sel.value)) {
-        sel.value = '';
+    if (opts.includes(oldValue)) {
+        sel.value = oldValue;
+    } else {
+        sel.value = value ?? opts[0] ?? '';
     }
 }


### PR DESCRIPTION
This PR was originally planned to just add a user selection to fix compiling executables, but it ended up becoming... this.

Resolves #18
Partially addresses #16 (adds a user folder path, but you still have to specify the runtimes folder too)
Resolves #15
Resolves #13
Resolves #5

This is my first time doing really anything related to GMEdit plugins, so there might be lots of bad code and issues.

- You can now specify a GameMaker user folder (%AppData%/GameMakerStudio2) and user in the control panel. This fixes compiling executables and allows using the IDE config and license files for YYC and <=2022 builds.
- Compiling on Windows and Mac now uses the PackageZip verb instead of trying (and failing) to use Package.
- Global runtime options actually save now.
- LTS and 2022 builds are now supported.
- Added support for YYC builds. I call the VM/YYC choice the "runner", to distinguish it from the Stable/Beta/LTS or runtime version choices that are called "runtime". 
- Igor is now passed the `/v` (verbose) flag, which GM also uses.
- Job tabs now display different finished messages for when builds fail or are cancelled.
- The runtime version can now be selected per-project.
- "Use Default" runtime choices are now displayed correctly in the control panel.